### PR TITLE
feat: 강사 및 강좌 관련 기능 

### DIFF
--- a/reservation-service/src/main/java/crafter_coder/domain/course/controller/AdminCourseController.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/controller/AdminCourseController.java
@@ -76,4 +76,12 @@ public class AdminCourseController {
             throw new MyException(MyErrorCode.INSTRUCTOR_ONLY);
         }
     }
+
+    @PutMapping("/{courseId}/status")
+    public ResponseEntity<ResponseDto<String>> updateCourseStatus(
+            @PathVariable Long courseId,
+            @RequestBody String status) {
+        courseService.updateCourseStatus(courseId, status);
+        return ResponseEntity.ok(ResponseDto.of(null, "강좌 상태 변경 성공"));
+    }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/course/controller/AdminCourseController.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/controller/AdminCourseController.java
@@ -1,0 +1,79 @@
+package crafter_coder.domain.course.controller;
+
+import crafter_coder.domain.course.dto.CourseDetailResponse;
+import crafter_coder.domain.course.dto.CourseListResponse;
+import crafter_coder.domain.course.dto.CourseRequest;
+import crafter_coder.domain.course.service.CourseService;
+import crafter_coder.domain.user.dto.UserResponseDto;
+import crafter_coder.domain.user.service.InstructorService;
+import crafter_coder.global.dto.ResponseDto;
+import crafter_coder.global.exception.MyErrorCode;
+import crafter_coder.global.exception.MyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/courses")
+@RequiredArgsConstructor
+public class AdminCourseController {
+// public class CourseController {
+
+    private final CourseService courseService;
+    private final InstructorService instructorService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<List<CourseListResponse>>> getCourses() {
+        List<CourseListResponse> response = courseService.getAllCourses();
+        return ResponseEntity.ok(ResponseDto.of(response, "전체 강좌 목록 조회"));
+    }
+
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ResponseDto<CourseDetailResponse>> getCourseDetail(@PathVariable Long courseId) {
+        return courseService.getCourseDetail(courseId)
+                .map(detail -> ResponseEntity.ok(ResponseDto.of(detail, "강좌 상세 정보 조회")))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<ResponseDto<Long>> createCourse(
+            @RequestBody CourseRequest courseRequest,
+            @RequestParam Long instructorId
+    ) {
+        validateInstructorRole(instructorId);
+        Long courseId = courseService.createCourse(courseRequest, instructorId);
+        return ResponseEntity.status(201).body(ResponseDto.of(courseId, "강좌 생성"));
+    }
+
+    @PutMapping("/{courseId}")
+    public ResponseEntity<ResponseDto<Void>> updateCourse(
+            @PathVariable Long courseId,
+            @RequestBody CourseRequest courseRequest,
+            @RequestParam Long instructorId
+    ) {
+        validateInstructorRole(instructorId);
+        courseService.updateCourse(courseId, courseRequest, instructorId);
+        return ResponseEntity.ok(ResponseDto.of(null, "강좌 수정"));
+    }
+
+    @GetMapping("/categories/{category}")
+    public ResponseEntity<ResponseDto<List<CourseListResponse>>> getCoursesByCategory(
+            @PathVariable String category) {
+        List<CourseListResponse> courses = courseService.getCoursesByCategory(category);
+        return ResponseEntity.ok(ResponseDto.of(courses, "카테고리별 강좌 목록 조회"));
+    }
+
+    @GetMapping("/{courseId}/users")
+    public ResponseEntity<ResponseDto<List<UserResponseDto>>> getCourseUsers(@PathVariable Long courseId) {
+        List<UserResponseDto> users = courseService.getCourseUsers(courseId);
+        return ResponseEntity.ok(ResponseDto.of(users, "강좌 수강 회원 목록 조회"));
+    }
+
+    private void validateInstructorRole(Long instructorId) {
+        if (instructorId == null || !instructorService.isValidInstructor(instructorId)) {
+            throw new MyException(MyErrorCode.INSTRUCTOR_ONLY);
+        }
+    }
+}

--- a/reservation-service/src/main/java/crafter_coder/domain/course/model/Course.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/model/Course.java
@@ -4,11 +4,11 @@ import crafter_coder.domain.course.dto.CourseRequest;
 import crafter_coder.domain.course.model.category.CourseCategory;
 import crafter_coder.domain.course.model.category.CourseSubCategory;
 import jakarta.persistence.*;
-import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -65,8 +65,11 @@ public class Course {
         return this.enrollmentCapacity.getCurrentEnrollment() == 0;
     }
 
-    public void updateStatus(String status) {
-        this.status = CourseStatus.valueOf(status.toUpperCase());
+    public void changeStatus(CourseStatus newStatus) {
+        if (!this.status.canChangeTo(newStatus)) {
+            throw new IllegalStateException("현재 상태에서 '" + newStatus.name() + "' 상태로 변경할 수 없습니다.");
+        }
+        this.status = newStatus;
     }
 
     private void setFields(String name, CourseSubCategory courseCategory, CourseDuration courseDuration,

--- a/reservation-service/src/main/java/crafter_coder/domain/course/model/Course.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/model/Course.java
@@ -13,7 +13,6 @@ import java.time.LocalDate;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -126,4 +125,7 @@ public class Course {
         this.enrollmentDeadline = LocalDate.parse(request.getEnrollmentDeadline());
     }
 
+    public Long getInstructorId() {
+        return instructorId;
+    }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/course/model/CourseStatus.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/model/CourseStatus.java
@@ -6,8 +6,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum CourseStatus {
-    OPEN,
-    CLOSED,
-    CANCELED,
-    ;
+    OPEN,     // 강좌 진행중
+    CLOSED,   // 모집 인원 마감
+    CANCELED, // 강좌 모집 취소
+    WAITING;  // 대기자 상태
+
+    public boolean canChangeTo(CourseStatus newStatus) {
+        if (this == CANCELED) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/course/repository/CourseRepository.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/repository/CourseRepository.java
@@ -1,7 +1,21 @@
 package crafter_coder.domain.course.repository;
 
 import crafter_coder.domain.course.model.Course;
+import crafter_coder.domain.user_course.model.UserCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    @Query("SELECT c FROM Course c WHERE c.courseCategory IN :subCategories")
+    List<Course> findBySubCategories(@Param("subCategories") List<String> subCategories);
+
+    @Query("SELECT c FROM Course c WHERE c.courseCategory = :category")
+    List<Course> findByCategory(@Param("category") String category);
+
+    @Query("SELECT uc FROM UserCourse uc WHERE uc.course.id = :courseId")
+    List<UserCourse> findByCourseId(@Param("courseId") Long courseId);
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/course/service/CourseService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/service/CourseService.java
@@ -4,12 +4,19 @@ import crafter_coder.domain.course.dto.CourseDetailResponse;
 import crafter_coder.domain.course.dto.CourseListResponse;
 import crafter_coder.domain.course.dto.CourseRequest;
 import crafter_coder.domain.course.model.Course;
+import crafter_coder.domain.course.model.category.CourseCategory;
+import crafter_coder.domain.course.model.category.CourseSubCategory;
 import crafter_coder.domain.course.repository.CourseRepository;
+import crafter_coder.domain.user.dto.UserResponseDto;
+import crafter_coder.domain.user_course.model.UserCourse;
+import crafter_coder.global.exception.MyErrorCode;
+import crafter_coder.global.exception.MyException;
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
-//import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -42,8 +49,61 @@ public class CourseService {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 강좌를 찾을 수 없습니다."));
         if (!course.getInstructorId().equals(instructorId)) {
-         //   throw new AccessDeniedException("해당 강좌를 수정할 권한이 없습니다.");
         }
         course.update(request);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CourseListResponse> getCoursesByCategory(String category) {
+        List<Course> courses = fetchCoursesByCategory(category);
+        return courses.stream()
+                .map(CourseListResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    private List<Course> fetchCoursesByCategory(String category) {
+        if (isTopCategory(category)) {
+            return getCoursesByTopCategory(category);
+        } else if (isSubCategory(category)) {
+            return getCoursesBySubCategory(category);
+        } else {
+            throw new MyException(MyErrorCode.INVALID_CATEGORY);
+        }
+    }
+
+    private boolean isTopCategory(String category) {
+        return Arrays.stream(CourseCategory.values())
+                .anyMatch(top -> top.name().equalsIgnoreCase(category));
+    }
+
+    private boolean isSubCategory(String category) {
+        return Arrays.stream(CourseSubCategory.values())
+                .anyMatch(sub -> sub.name().equalsIgnoreCase(category));
+    }
+
+    private List<Course> getCoursesByTopCategory(String category) {
+        CourseCategory topCategory = CourseCategory.valueOf(category.toUpperCase());
+        List<String> subCategories = Arrays.stream(CourseSubCategory.values())
+                .filter(sub -> sub.getCategory() == topCategory)
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        return courseRepository.findBySubCategories(subCategories);
+    }
+
+    private List<Course> getCoursesBySubCategory(String category) {
+        return courseRepository.findByCategory(category.toUpperCase());
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserResponseDto> getCourseUsers(Long courseId) {
+        List<UserCourse> userCourses = courseRepository.findByCourseId(courseId);
+
+        if (userCourses.isEmpty()) {
+            throw new MyException(MyErrorCode.COURSE_NOT_FOUND);
+        }
+
+        return userCourses.stream()
+                .map(userCourse -> UserResponseDto.of(userCourse.getUser()))
+                .collect(Collectors.toList());
     }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/course/service/CourseService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/course/service/CourseService.java
@@ -4,6 +4,7 @@ import crafter_coder.domain.course.dto.CourseDetailResponse;
 import crafter_coder.domain.course.dto.CourseListResponse;
 import crafter_coder.domain.course.dto.CourseRequest;
 import crafter_coder.domain.course.model.Course;
+import crafter_coder.domain.course.model.CourseStatus;
 import crafter_coder.domain.course.model.category.CourseCategory;
 import crafter_coder.domain.course.model.category.CourseSubCategory;
 import crafter_coder.domain.course.repository.CourseRepository;
@@ -105,5 +106,21 @@ public class CourseService {
         return userCourses.stream()
                 .map(userCourse -> UserResponseDto.of(userCourse.getUser()))
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateCourseStatus(Long courseId, String status) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new MyException(MyErrorCode.COURSE_NOT_FOUND));
+
+        CourseStatus newStatus;
+        try {
+            newStatus = CourseStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new MyException(MyErrorCode.INVALID_STATUS);
+        }
+
+        course.changeStatus(newStatus);
+        courseRepository.save(course);
     }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/controller/AdminInstructorRequestController.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/controller/AdminInstructorRequestController.java
@@ -1,0 +1,45 @@
+package crafter_coder.domain.instructor.controller;
+
+import crafter_coder.domain.instructor.dto.InstructorRequestDto;
+import crafter_coder.domain.instructor.service.InstructorRequestService;
+import crafter_coder.global.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/instructors/requests")
+@RequiredArgsConstructor
+public class AdminInstructorRequestController {
+
+    private final InstructorRequestService requestService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<List<InstructorRequestDto>>> getAllRequests(
+            @RequestParam(required = false) String status) {
+        List<InstructorRequestDto> requests = requestService.getAllRequests(status);
+        return ResponseEntity.ok(ResponseDto.of(requests, "관리자 권한으로 모든 강사 요청 목록 조회"));
+    }
+
+    @GetMapping("/{requestId}")
+    public ResponseEntity<ResponseDto<InstructorRequestDto>> getRequestDetail(@PathVariable Long requestId) {
+        InstructorRequestDto requestDetail = requestService.getRequestDetail(requestId);
+        return ResponseEntity.ok(ResponseDto.of(requestDetail, "관리자 권한으로 요청 상세 정보 조회"));
+    }
+
+    @PutMapping("/{requestId}/approve")
+    public ResponseEntity<ResponseDto<Void>> approveRequest(@PathVariable Long requestId) {
+        requestService.approveRequest(requestId);
+        return ResponseEntity.ok(ResponseDto.of(null, "요청 승인 완료"));
+    }
+
+    @PutMapping("/{requestId}/reject")
+    public ResponseEntity<ResponseDto<Void>> rejectRequest(
+            @PathVariable Long requestId,
+            @RequestBody String reason) {
+        requestService.rejectRequest(requestId, reason);
+        return ResponseEntity.ok(ResponseDto.of(null, "요청 거부 완료"));
+    }
+}

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/controller/InstructorRequestController.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/controller/InstructorRequestController.java
@@ -25,7 +25,7 @@ public class InstructorRequestController {
                 instructorId, courseId, requestDto.getStatus(), requestDto.getDayOfWeek(),
                 requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getMaxCapacity(),
                 requestDto.getStartDate(), requestDto.getEndDate());
-        return ResponseEntity.ok(ResponseDto.of(null, "강좌 수정 요청"));
+        return ResponseEntity.ok(ResponseDto.of(null, "강좌 수정 요청 조회"));
     }
 
     @PostMapping("/courses/{courseId}/delete")
@@ -34,7 +34,7 @@ public class InstructorRequestController {
             @PathVariable Long courseId,
             @RequestBody InstructorRequestDto requestDto) {
         requestService.createDeleteRequest(instructorId, courseId, requestDto.getReason());
-        return ResponseEntity.ok(ResponseDto.of(null, "강좌 삭제 요청"));
+        return ResponseEntity.ok(ResponseDto.of(null, "강좌 삭제 요청 조회"));
     }
 
     @GetMapping

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/model/InstructorRequest.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/model/InstructorRequest.java
@@ -32,7 +32,7 @@ public class InstructorRequest {
     @Column(nullable = false)
     private RequestType type;
 
-    @Column(name = "requested_at", nullable = false)
+    @Column(nullable = false)
     private LocalDate requestedAt;
 
     @Column(nullable = true)
@@ -72,5 +72,19 @@ public class InstructorRequest {
         request.requestedAt = LocalDate.now();
         request.reason = reason;
         return request;
+    }
+
+
+    public void markAsCompleted() {
+        this.status = "COMPLETED";
+    }
+
+    public void approve() {
+        this.status = "APPROVED";
+    }
+
+    public void reject(String reason) {
+        this.status = "REJECTED";
+        this.reason = reason;
     }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/repository/InstructorRequestRepository.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/repository/InstructorRequestRepository.java
@@ -3,9 +3,13 @@ package crafter_coder.domain.instructor.repository;
 import crafter_coder.domain.instructor.model.InstructorRequest;
 import crafter_coder.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface InstructorRequestRepository extends JpaRepository<InstructorRequest, Long> {
     List<InstructorRequest> findByInstructor(User instructor);
+    @Query("SELECT r FROM InstructorRequest r WHERE (:status IS NULL OR r.status = :status)")
+    List<InstructorRequest> findByStatus(@Param("status") String status);
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/service/AdminInstructorService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/service/AdminInstructorService.java
@@ -1,6 +1,7 @@
 package crafter_coder.domain.instructor.service;
 
 import crafter_coder.domain.course.model.Course;
+import crafter_coder.domain.course.model.CourseStatus;
 import crafter_coder.domain.course.repository.CourseRepository;
 import crafter_coder.domain.instructor.dto.CourseUpdateRequestDto;
 import crafter_coder.domain.instructor.dto.InstructorResponseDto;
@@ -75,9 +76,16 @@ public class AdminInstructorService {
         validateInstructor(instructorId);
 
         Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new MyException(MyErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new MyException(MyErrorCode.COURSE_NOT_FOUND));
 
-        course.updateStatus(status);
+        CourseStatus newStatus;
+        try {
+            newStatus = CourseStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new MyException(MyErrorCode.INVALID_STATUS);
+        }
+
+        course.changeStatus(newStatus);
     }
 
     private void validateInstructor(Long instructorId) {

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/service/InstructorRequestService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/service/InstructorRequestService.java
@@ -2,6 +2,7 @@ package crafter_coder.domain.instructor.service;
 
 import crafter_coder.domain.course.model.Course;
 import crafter_coder.domain.course.repository.CourseRepository;
+import crafter_coder.domain.instructor.dto.InstructorRequestDto;
 import crafter_coder.domain.instructor.model.InstructorRequest;
 import crafter_coder.domain.instructor.repository.InstructorRequestRepository;
 import crafter_coder.domain.user.model.Role;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +30,8 @@ public class InstructorRequestService {
     public void createUpdateRequest(Long instructorId, Long courseId, String status, String dayOfWeek, String startTime,
                                     String endTime, Integer maxCapacity, LocalDate startDate, LocalDate endDate) {
         User instructor = validateInstructor(instructorId);
+        validateCourseOwnership(instructorId, courseId);
+
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new MyException(MyErrorCode.COURSE_NOT_FOUND));
         InstructorRequest request = InstructorRequest.createUpdateRequest(
@@ -38,10 +42,51 @@ public class InstructorRequestService {
     @Transactional
     public void createDeleteRequest(Long instructorId, Long courseId, String reason) {
         User instructor = validateInstructor(instructorId);
+        validateCourseOwnership(instructorId, courseId);
+
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new MyException(MyErrorCode.COURSE_NOT_FOUND));
         InstructorRequest request = InstructorRequest.createDeleteRequest(instructor, course, reason);
         requestRepository.save(request);
+    }
+
+    @Transactional
+    public void completeRequest(Long requestId) {
+        InstructorRequest request = requestRepository.findById(requestId)
+                .orElseThrow(() -> new MyException(MyErrorCode.REQUEST_NOT_FOUND));
+        request.markAsCompleted();
+    }
+
+    @Transactional
+    public void approveRequest(Long requestId) {
+        InstructorRequest request = requestRepository.findById(requestId)
+                .orElseThrow(() -> new MyException(MyErrorCode.REQUEST_NOT_FOUND));
+        request.approve();
+    }
+
+    @Transactional
+    public void rejectRequest(Long requestId, String reason) {
+        InstructorRequest request = requestRepository.findById(requestId)
+                .orElseThrow(() -> new MyException(MyErrorCode.REQUEST_NOT_FOUND));
+        request.reject(reason);
+    }
+
+    @Transactional(readOnly = true)
+    public List<InstructorRequestDto> getAllRequests(String status) {
+        List<InstructorRequest> requests = (status == null)
+                ? requestRepository.findAll()
+                : requestRepository.findByStatus(status);
+
+        return requests.stream()
+                .map(InstructorRequestDto::of)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public InstructorRequestDto getRequestDetail(Long requestId) {
+        InstructorRequest request = requestRepository.findById(requestId)
+                .orElseThrow(() -> new MyException(MyErrorCode.REQUEST_NOT_FOUND));
+        return InstructorRequestDto.of(request);
     }
 
     @Transactional(readOnly = true)
@@ -54,5 +99,13 @@ public class InstructorRequestService {
         return userRepository.findById(instructorId)
                 .filter(user -> user.getRole() == Role.INSTRUCTIOR)
                 .orElseThrow(() -> new MyException(MyErrorCode.INSTRUCTOR_ONLY));
+    }
+
+    private void validateCourseOwnership(Long instructorId, Long courseId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new MyException(MyErrorCode.COURSE_NOT_FOUND));
+        if (!course.getInstructorId().equals(instructorId)) {
+            throw new MyException(MyErrorCode.INSTRUCTOR_ONLY);
+        }
     }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/instructor/service/InstructorRequestService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/instructor/service/InstructorRequestService.java
@@ -1,9 +1,11 @@
 package crafter_coder.domain.instructor.service;
 
 import crafter_coder.domain.course.model.Course;
+import crafter_coder.domain.course.model.CourseStatus;
 import crafter_coder.domain.course.repository.CourseRepository;
 import crafter_coder.domain.instructor.dto.InstructorRequestDto;
 import crafter_coder.domain.instructor.model.InstructorRequest;
+import crafter_coder.domain.instructor.model.RequestType;
 import crafter_coder.domain.instructor.repository.InstructorRequestRepository;
 import crafter_coder.domain.user.model.Role;
 import crafter_coder.domain.user.model.User;
@@ -61,6 +63,11 @@ public class InstructorRequestService {
     public void approveRequest(Long requestId) {
         InstructorRequest request = requestRepository.findById(requestId)
                 .orElseThrow(() -> new MyException(MyErrorCode.REQUEST_NOT_FOUND));
+
+        if (request.getType() == RequestType.DELETE) {
+            deleteCourse(request.getCourse().getId());
+        }
+
         request.approve();
     }
 
@@ -107,5 +114,14 @@ public class InstructorRequestService {
         if (!course.getInstructorId().equals(instructorId)) {
             throw new MyException(MyErrorCode.INSTRUCTOR_ONLY);
         }
+    }
+
+    private void deleteCourse(Long courseId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new MyException(MyErrorCode.COURSE_NOT_FOUND));
+
+        course.changeStatus(CourseStatus.CANCELED);
+
+        courseRepository.delete(course);
     }
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/user/controller/UserAdminController.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/user/controller/UserAdminController.java
@@ -1,5 +1,6 @@
 package crafter_coder.domain.user.controller;
 
+import crafter_coder.domain.user.dto.UserCourseReservationDto;
 import crafter_coder.domain.user.dto.UserRecordResponseDto;
 import crafter_coder.domain.user.dto.UserResponseDto;
 import crafter_coder.domain.user.service.UserAdminService;
@@ -40,4 +41,11 @@ public class UserAdminController {
         userAdminService.updateUserStatus(id, status);
         return ResponseEntity.ok(ResponseDto.of(null, "회원 상태 변경 성공"));
     }
+
+    @GetMapping("/{id}/courses")
+    public ResponseEntity<ResponseDto<List<UserCourseReservationDto>>> getUserCourseReservations(@PathVariable Long id) {
+        List<UserCourseReservationDto> reservations = userAdminService.getUserCourseReservations(id);
+        return ResponseEntity.ok(ResponseDto.of(reservations, "회원 강좌 예약 현황 조회 성공"));
+    }
+
 }

--- a/reservation-service/src/main/java/crafter_coder/domain/user/dto/UserCourseReservationDto.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/user/dto/UserCourseReservationDto.java
@@ -1,0 +1,21 @@
+package crafter_coder.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserCourseReservationDto {
+    private Long courseId;
+    private String courseName;
+    private String status;
+    private String paymentStatus;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String dayOfWeek;
+    private String startTime;
+    private String endTime;
+    private String instructorName;
+}

--- a/reservation-service/src/main/java/crafter_coder/domain/user/service/InstructorService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/user/service/InstructorService.java
@@ -1,0 +1,28 @@
+package crafter_coder.domain.user.service;
+
+import crafter_coder.domain.user.model.Role;
+import crafter_coder.domain.user.model.User;
+import crafter_coder.domain.user.repository.UserRepository;
+import crafter_coder.global.exception.MyErrorCode;
+import crafter_coder.global.exception.MyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InstructorService {
+
+    private final UserRepository userRepository;
+
+    public boolean isValidInstructor(Long instructorId) {
+        return userRepository.findById(instructorId)
+                .filter(user -> user.getRole() == Role.INSTRUCTIOR)
+                .isPresent();
+    }
+
+    public User getInstructor(Long instructorId) {
+        return userRepository.findById(instructorId)
+                .filter(user -> user.getRole() == Role.INSTRUCTIOR)
+                .orElseThrow(() -> new MyException(MyErrorCode.INSTRUCTOR_ONLY));
+    }
+}

--- a/reservation-service/src/main/java/crafter_coder/domain/user/service/UserService.java
+++ b/reservation-service/src/main/java/crafter_coder/domain/user/service/UserService.java
@@ -32,7 +32,8 @@ public class UserService {
                 registerRequestDto.getAccountId(),
                 registerRequestDto.getAccountPassword(),
                 registerRequestDto.getRole(),
-                registerRequestDto.getStatus()
+                registerRequestDto.getStatus(),
+                registerRequestDto.getSpecialization()
         );
 
         userRepository.save(user);

--- a/reservation-service/src/main/java/crafter_coder/global/exception/MyErrorCode.java
+++ b/reservation-service/src/main/java/crafter_coder/global/exception/MyErrorCode.java
@@ -22,7 +22,9 @@ public enum MyErrorCode {
     INVALID_REQUEST_DATA(HttpStatus.BAD_REQUEST, "요청 데이터가 잘못되었습니다."),
     CANNOT_UPDATE_COURSE(HttpStatus.BAD_REQUEST, "강좌 상태를 변경할 수 없습니다."),
     CANNOT_DELETE_COURSE(HttpStatus.BAD_REQUEST, "강좌 삭제 요청을 처리할 수 없습니다."),
-    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID로 조회된 강사 요청을 찾을 수 없습니다.");
+    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID로 조회된 강사 요청을 찾을 수 없습니다."),
+
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "잘못된 카테고리입니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 📋 이슈 번호
    #19 #20
## 🛠 구현 사항
- 강사 목록 및 정보 조회
- 강사의 요청에 따라 강좌 수정/삭제
- 관리자가 모든 강사의 요청 목록 확인
- 관리자가 특정 요청의 상세 정보 확인

- 모든 강좌 목록 조회
- 카테고리별 강좌 목록 조회
- 해당 강좌의 수강 회원 목록 조회
- 해당 회원의 강좌 예약 현황(예약 완료/예약 취소) 조회
- 강사의 요청에 따라 강좌 상태(진행중, 마감, 취소, 대기중) 변경
## 📚 기타
결제 연동하는 부분 제외하고 구현된 기능입니다.